### PR TITLE
Remove X-Requested-With

### DIFF
--- a/backbone.nativeajax.js
+++ b/backbone.nativeajax.js
@@ -104,7 +104,6 @@
           xhrAccepts["*"]
       );
 
-      xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
       if (options.headers) for (var key in options.headers) {
         xhr.setRequestHeader(key, options.headers[key]);
       }


### PR DESCRIPTION
There is no API to “undo” setting request headers on XHR so it really should be up to the client to specify this (or any other) header.
