### PR TITLE
Don't try to parse empty response

### DIFF
--- a/backbone.nativeajax.js
+++ b/backbone.nativeajax.js
@@ -23,7 +23,7 @@
       if (accepts == null) accepts = xhr.getResponseHeader('content-type');
       if (xmlRe.test(accepts)) {
         return xhr.responseXML;
-      } else if (jsonRe.test(accepts)) {
+      } else if (jsonRe.test(accepts) && xhr.responseText !== '') {
         return JSON.parse(xhr.responseText);
       } else {
         return xhr.responseText;


### PR DESCRIPTION
I'm not sure if you need this, but we faced a problem when our server returned 204 (No Content) for DELETE actions but Backbone.NativeAjax assumed a JSON response. This is a quick fix but there is perhaps a better way.
