### PR TITLE
Event readystatechange should be used as attribute solely

### DIFF
--- a/backbone.nativeajax.js
+++ b/backbone.nativeajax.js
@@ -89,7 +89,7 @@
         }
       }
 
-      xhr.addEventListener('readystatechange', end(xhr, options, resolve, reject));
+      xhr.onreadystatechange = end(xhr, options, resolve, reject);
       xhr.open(options.type, options.url, true);
 
       var allTypes = "*/".concat("*");


### PR DESCRIPTION
As stated here:
  http://www.w3.org/TR/XMLHttpRequest/#event-handlers

Event 'readystatechange' should be defined as attribute
on xhr object.

Current implementation does not play well with jasmine-ajax
library. This fix allow application using Backbone.NativeAjax
to be tested with jasmine and jasmine-ajax library.