### PR TITLE
Set default accept header only when none is provided

### DIFF
--- a/backbone.nativeajax.js
+++ b/backbone.nativeajax.js
@@ -110,20 +110,22 @@
       xhr.onreadystatechange = end(xhr, options, promise, resolve, reject);
       xhr.open(options.type, options.url, true);
 
-      var allTypes = "*/".concat("*");
-      var xhrAccepts = {
-        "*": allTypes,
-        text: "text/plain",
-        html: "text/html",
-        xml: "application/xml, text/xml",
-        json: "application/json, text/javascript"
-      };
-      xhr.setRequestHeader(
-        "Accept",
-        options.dataType && xhrAccepts[options.dataType] ?
-          xhrAccepts[options.dataType] + (options.dataType !== "*" ? ", " + allTypes + "; q=0.01" : "" ) :
-          xhrAccepts["*"]
-      );
+      if(!(options.headers && options.headers.Accept)) {
+        var allTypes = "*/".concat("*");
+        var xhrAccepts = {
+          "*": allTypes,
+          text: "text/plain",
+          html: "text/html",
+          xml: "application/xml, text/xml",
+          json: "application/json, text/javascript"
+        };
+        xhr.setRequestHeader(
+          "Accept",
+          options.dataType && xhrAccepts[options.dataType] ?
+            xhrAccepts[options.dataType] + (options.dataType !== "*" ? ", " + allTypes + "; q=0.01" : "" ) :
+            xhrAccepts["*"]
+        );
+      }
 
       if (options.headers) for (var key in options.headers) {
         xhr.setRequestHeader(key, options.headers[key]);

--- a/test/ajax.js
+++ b/test/ajax.js
@@ -56,6 +56,13 @@ describe('Backbone.NativeAjax', function() {
       expect(setRequestHeader).to.have.been.calledThrice;
       // expect(setRequestHeader.firstCall).to.have.been.calledWithExactly()
     });
+
+    it('should use custom accept header if passed in', function() {
+      ajax({url: 'test', dataType: 'json', headers: {Accept: 'application/xml, application/json;q=0.9'}});
+
+      expect(setRequestHeader).to.have.been.calledOnce;
+      expect(setRequestHeader).to.have.been.calledWithExactly('Accept', 'application/xml, application/json;q=0.9');
+    });
   });
 
   describe('finishing a request', function() {


### PR DESCRIPTION
Set the accept header based on the data type only when no accept header is specified with the options object. Otherwise the user does not have any possibility to override the default accept headers.

In my case I want to specify the following accept header:
`application/vnd.json, application/json;q=0.9`

However, in the current implementation, my custom accept header is only appended to the default one (see specification of [setRequestHeader](http://www.w3.org/TR/XMLHttpRequest/#the-setrequestheader%28%29-method)) and so the actual accept header looks like this:
`application/json, text/javascript, */*; q=0.01, application/vnd.json,application/json;q=0.9`
In this case the normal JSON MIME type has the same preference as `application/vnd.json` which is not what I intended.
