### PR TITLE
Add ability to override ajax async flag

### DIFF
--- a/backbone.nativeajax.js
+++ b/backbone.nativeajax.js
@@ -108,7 +108,7 @@
       }
 
       xhr.onreadystatechange = end(xhr, options, promise, resolve, reject);
-      xhr.open(options.type, options.url, true);
+      xhr.open(options.type, options.url, options.async !== false);
 
       if(!(options.headers && options.headers.Accept)) {
         var allTypes = "*/".concat("*");


### PR DESCRIPTION
There is no ability to override async flag, but using synchronous requests is the only way for [cases like this](http://stackoverflow.com/questions/10223388/window-open-works-different-on-ajax-success).