### PR TITLE
Respect content type negotiation

### DIFF
--- a/backbone.nativeajax.js
+++ b/backbone.nativeajax.js
@@ -35,11 +35,13 @@
       }
       if (!contentType) {
         var acceptHeader = options.headers && options.headers.Accept;
-        var accepts = acceptHeader.replace(/;[^,]*/g, '').split(/\s*,\s*/);
-        for (var i=0; i<accepts.length; i++) {
-          contentType = parseMimeType(accepts[i]);
-          if (contentType) {
-            break;
+        if (acceptHeader) {
+          var accepts = acceptHeader.replace(/;[^,]*/g, '').split(/\s*,\s*/);
+          for (var i=0; i<accepts.length; i++) {
+            contentType = parseMimeType(accepts[i]);
+            if (contentType) {
+              break;
+            }
           }
         }
       }

--- a/backbone.nativeajax.js
+++ b/backbone.nativeajax.js
@@ -55,9 +55,7 @@
           break;
         case 'json':
           if (xhr.responseText !== '') {
-            try {
-              data = JSON.parse(xhr.responseText);
-            } catch(e) {}
+            data = JSON.parse(xhr.responseText);
           }
           break;
       }


### PR DESCRIPTION
Use the following rules to determine the response data type
1. Use `options.dataType` if present
2. Try to parse from the response content type header
3. Try to parse from the request accept header

Previously, only the first accept header MIME type was taken into account.

fixes #10
