### PR TITLE
Add extension to main

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Adam Krebs <amk528@cs.nyu.edu>",
   "description": "A Backbone.Ajax function powered by native XHR methods",
   "license": "MIT",
-  "main": "backbone.nativeajax",
+  "main": "backbone.nativeajax.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/akre54/backbone.nativeajax"


### PR DESCRIPTION
See brunch/brunch#1388 for the rationale. The period in the file name minus extension breaks some tooling, and it seems to be an easy fix to make here.

Thanks!