### PR TITLE
fix Blackberry errors on proxyPromise

### DIFF
--- a/backbone.nativeajax.js
+++ b/backbone.nativeajax.js
@@ -66,9 +66,13 @@
 
       for (var i = 0; i < props.length; i++) {
         var prop = props[i];
-        promise[prop] = typeof xhr[prop] === 'function' ?
-                              xhr[prop].bind(xhr) :
-                              xhr[prop];
+        try {
+          promise[prop] = typeof xhr[prop] === 'function' ?
+                                xhr[prop].bind(xhr) :
+                                xhr[prop];
+        } catch (e) {
+          console.log(e);
+        }
       }
       return promise;
     }


### PR DESCRIPTION
experiencing issues (500 error) w/ proxyPromise on Blackberry 10. it seems that, when xhr.readyState is 0 or 1, accessing xhr.status and xhr.statusText throws an exception
